### PR TITLE
Small change to Events display page

### DIFF
--- a/app/models/User.java
+++ b/app/models/User.java
@@ -161,7 +161,7 @@ public boolean isFriendsWith(User user) {
 	return false;
 }
 
-  /** Get all created events
+  /** Get all authored events
    *
    * @return a list of events that User has authored
    */

--- a/app/models/User.java
+++ b/app/models/User.java
@@ -166,6 +166,6 @@ public boolean isFriendsWith(User user) {
    * @return a list of events that User has authored
    */
   public List<Event> authoredEvents() {
-    return Event.find("SELECT r FROM Event r where r.author = ? and r.open = true", this).fetch();
+    return Event.find("SELECT r FROM Event r where r.author = ?", this).fetch();
   }
 }

--- a/app/models/User.java
+++ b/app/models/User.java
@@ -160,4 +160,12 @@ public boolean isFriendsWith(User user) {
 	}
 	return false;
 }
+
+  /** Get all created events
+   *
+   * @return a list of events that User has authored
+   */
+  public List<Event> authoredEvents() {
+    return Event.find("SELECT r FROM Event r where r.author = ? and r.open = true", this).fetch();
+  }
 }

--- a/app/views/Events/events.html
+++ b/app/views/Events/events.html
@@ -2,7 +2,7 @@
 <h2> Events </h2>
 <a class=button href="@{Events.addEvent()}">+ Create Event</a><br /><br />
 
-To Do: currently only lists "public" events user authored, eventually list all attending by start date<br />
+To Do: currently only lists events user authored, eventually list all attending by start date<br />
 <h3>My Events:</h3>
 #{list items:user.authoredEvents(), as:'authorEvent'}
 <a href="@{Events.displayEvent(authorEvent.id)}">${ authorEvent.eventName }</a>

--- a/app/views/Events/events.html
+++ b/app/views/Events/events.html
@@ -1,4 +1,11 @@
 #{extends 'main.html' /}
-To Do: should list events:
-<a class=button href="@{Events.addEvent()}">+ Create Event</a>
+<h2> Events </h2>
+<a class=button href="@{Events.addEvent()}">+ Create Event</a><br /><br />
+
+To Do: currently only lists "public" events user authored, eventually list all attending by start date<br />
+<h3>My Events:</h3>
+#{list items:user.authoredEvents(), as:'authorEvent'}
+<a href="@{Events.displayEvent(authorEvent.id)}">${ authorEvent.eventName }</a>
+<a id="event-button" href="@{Events.deleteEvent(authorEvent.id, user.id)}">remove event</a><br />
+#{/list}
 


### PR DESCRIPTION
Now displays all Events authored by the current User and gives the option to delete them.

Known Issues:
Events can have end dates occurring before start dates and display of Events is unordered

Features to Add:
Order events by start date
Display events that the User was invited to (once Event Invites are created)
Allow User to Accept/Reject Event Invites once those are in place
