### PR TITLE
Re-formatted display of Events

### DIFF
--- a/app/controllers/Events.java
+++ b/app/controllers/Events.java
@@ -83,6 +83,7 @@ public class Events extends OBController {
 				&& !endDay.equals("-1") 
 				&& !endTime.equals("-1")) {
 				event.endDate = setDate(endTime, endMonth, endDay);
+				event.givenEndDate = true;
 			}
 
 			if (curEvent.privilege.equals("open")) {
@@ -103,9 +104,57 @@ public class Events extends OBController {
 		Event e = Event.findById(id);
 		String name = e.eventName;
 		String location = e.eventLocation;
-		Date start = e.startDate;
-		Date end = e.endDate;
-		render(name, location, start, end);
+		Date myDateStart = e.startDate;		
+		String myDate = convertDateMonth(myDateStart) + " " + myDateStart.getDate() + " at " + convertDateTime(myDateStart);
+		String description = e.eventScript;
+		String myAuthor = e.author.name;
+		
+		String privacy = "";
+		if(e.open){ privacy = "Public Event"; }
+		else if(e.friends){ privacy = "Friends Event"; }
+		else { privacy = "Invite Only Event"; }
+		
+		if (e.givenEndDate){
+			Date myDateEnd = e.endDate;			
+			if ((myDateStart.getMonth() == myDateEnd.getMonth()) && (myDateStart.getDate() == myDateEnd.getDate())){
+				myDate += " until " + convertDateTime(myDateEnd);
+			}
+			else {
+				myDate += " until " + convertDateMonth(myDateEnd) + " " + myDateEnd.getDate() + " at " + convertDateTime(myDateEnd);
+			}
+		}
+		render(name, privacy, myAuthor, myDate, location, description);
+	}
+	
+	public static String convertDateMonth(Date myDate){
+		int month = myDate.getMonth();
+		if (month == 0){ return "January"; }
+		else if (month == 1){ return "February"; }
+		else if (month == 2){ return "March"; }
+		else if (month == 3){ return "April"; }
+		else if (month == 4){ return "May"; }
+		else if (month == 5){ return "June"; }
+		else if (month == 6){ return "July"; }
+		else if (month == 7){ return "August"; }
+		else if (month == 8){ return "September"; }
+		else if (month == 9){ return "October"; }
+		else if (month == 10){ return "November"; }
+		else { return "December"; }
+	}
+	
+	public static String convertDateTime(Date myDate){
+		String ret = "";
+		int hour = myDate.getHours(); 
+		String ampm = "";
+		if (hour == 0) { hour = 12; ampm = "AM"; }
+		else if (hour >= 1 && hour <= 11) { ampm = "AM"; }
+		else{ hour = hour - 12; ampm = "PM"; }
+		ret += hour;
+		int minutes= myDate.getMinutes();
+		if (minutes < 9){ ret += ":0" + minutes; }
+		else { ret += ":" + minutes; }
+		ret += " " + ampm;
+		return ret;
 	}
 	
 	public static Date setDate(String time, String month, String day){

--- a/app/models/Event.java
+++ b/app/models/Event.java
@@ -24,6 +24,7 @@ public class Event extends Model {
 	public String eventLocation;
 	public Date startDate;
 	public Date endDate;
+	public boolean givenEndDate = false;
 	
 	public String privilege; 
 	public boolean open = false;

--- a/app/views/Events/displayEvent.html
+++ b/app/views/Events/displayEvent.html
@@ -1,5 +1,8 @@
 #{extends 'main.html' /}
 <h1>${name}<h1>
-<h2>Location: ${location}<h2>
-<h2>Starts at: ${start}<h2>
-<h2>Ends at: ${end}<h2>
+<h3> ${privacy} By ${myAuthor}<h3>
+<h3>${myDate}<h3>
+<h3>Location: ${location}<h3>
+<h3>Details: ${description}<h3>
+</br>
+<a class=button href="@{Events.events()}">< Events</a><br /><br />

--- a/app/views/Events/events.html
+++ b/app/views/Events/events.html
@@ -6,6 +6,6 @@ To Do: currently only lists events user authored, eventually list all attending 
 <h3>My Events:</h3>
 #{list items:user.authoredEvents(), as:'authorEvent'}
 <a href="@{Events.displayEvent(authorEvent.id)}">${ authorEvent.eventName }</a>
-<a id="event-button" href="@{Events.deleteEvent(authorEvent.id, user.id)}">remove event</a><br />
+<a class=button href="@{Events.deleteEvent(authorEvent.id, user.id)}">Remove Event</a><br />
 #{/list}
 


### PR DESCRIPTION
Re-formatted display of Events to more effectively display the start and end times (FIX: no longer displays end dates if there isn't an end date to display). 

Known issues:
Still need to handle if the start date comes after the end date
Still need to order Events by start date on the event main page for the user
Still need to create Event Invites
