### PR TITLE
Added Posts to Event pages and basic Event membership

### DIFF
--- a/app/controllers/Events.java
+++ b/app/controllers/Events.java
@@ -1,11 +1,13 @@
 package controllers;
 
+import java.util.*;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
 import models.Event;
+import models.Post;
 import models.User;
 import play.mvc.Before;
 import play.mvc.With;
@@ -79,7 +81,8 @@ public class Events extends OBController {
 			} else if (curEvent.privilege.equals("inviteOnly")) {
 				event.inviteOnly = true;
 			}
-
+			event.members= new ArrayList<User>();
+			event.members.add(currentUser);
 			event.save();
 			displayEvent(event.id);
 
@@ -93,6 +96,7 @@ public class Events extends OBController {
 		Date myDateStart = e.startDate;		
 		String myDate = convertDateToString(myDateStart);
 		String description = e.eventScript;
+		User user = user();
 		String myAuthor = e.author.name;
 		
 		String privacy = "";
@@ -111,7 +115,7 @@ public class Events extends OBController {
 				myDate += " until " + convertDateToString(myDateEnd);
 			}
 		}
-		render(name, privacy, myAuthor, myDate, location, description);
+		render(e, user, name, privacy, myAuthor, myDate, location, description);
 	}
 	
 	public static String convertDateToString(Date myDate){
@@ -138,5 +142,10 @@ public class Events extends OBController {
 		Calendar cal = Calendar.getInstance();
 		cal.set(cal.get(Calendar.YEAR), Integer.parseInt(month), Integer.parseInt(day), hours, minutes);
 		return cal.getTime();
+	}
+	
+	public static void newEventPost(Long eventId, Long userId, String post_content){
+		new Post((User)User.findById(userId), eventId.toString(), post_content, Post.type.EVENT).save();
+		events(eventId);
 	}
 }

--- a/app/models/Event.java
+++ b/app/models/Event.java
@@ -5,6 +5,8 @@ import javax.persistence.*;
 import play.data.validation.*;
 
 import controllers.Events;
+import controllers.Application;
+import models.Post;
 
 import play.db.jpa.*;
 
@@ -32,11 +34,16 @@ public class Event extends Model {
 	public boolean inviteOnly = false;
 	//public Location eventVenue;
 	
+	@OneToMany
+	public List<User> members;
+	
 	public Event(User author, String eventName, String eventScript, String eventLocation){		
 		this.author = author;
 		this.eventName = eventName;
 		this.eventScript = eventScript;
 		this.eventLocation = eventLocation;
+		this.members= new ArrayList<User>();
+		this.members.add(author);
 	}
 	
 	public EventInvite newEventInvite(User curGuest) {
@@ -44,4 +51,22 @@ public class Event extends Model {
 		this.save();
 		return myEventInvite;
 	}	
+	
+	public List<Post> getPosts(){
+      return Post.find("SELECT p FROM Post p WHERE p.postType = ? and p.title = ? order by p.updatedAt desc",Post.type.EVENT,this.id.toString()).fetch();
+	}
+	
+	public void addMember(User u){
+		if(!members.contains(u))
+			members.add(u);
+	}
+	
+	public void removeMember(User u){
+		if(members.contains(u))
+			members.remove(u);
+	}
+	
+	public int getMemberCount(){
+		return members.size();
+	}
 }

--- a/app/views/Events/displayEvent.html
+++ b/app/views/Events/displayEvent.html
@@ -4,5 +4,95 @@
 <h3>${myDate}<h3>
 <h3>Location: ${location}<h3>
 <h3>Details: ${description}<h3>
+<h4>The Event members:</h4>
+        #{list items:e.members, as:'member'}
+        <a href="@{Application.about(member.id)}">${member.name}</a><br>
+        #{/list}
 </br>
+
+#{if user.id == currentUser.id}
+      	  #{form @Events.newEventPost(e.id,user.id)}
+            <textarea name="post_content" id="postContent" style="resize: none;" rows="2" cols="45"></textarea>
+            <input type="submit" value="Post" />
+          #{/form}
+    #{/if}
+    #{list items:e.getPosts(), as:'item'}
+      <div class="post">
+        <div class="hideable">
+          <div class="left">
+            <img style="width:50px; height:50px;" src=@{Photos.getPhoto(item.author.profile.profilePhoto)} />
+          </div>
+          
+          <div class="individual-post">
+            <span class="post-author"><a href="@{Application.news(item.author.id)}">${ item.author.name }</a></span>
+            <div class="post-content tohideopp">
+              ${item.contentTeaser().nl2br()}
+              <a class='triggershow showfirst' href='#' onclick='return false;'> +more </a>
+            </div>
+            <div class="tohide hide">
+              <div class="post-content">
+                ${item.content.nl2br()}
+              </div>
+              #{list items:item.getComments(), as:'comment'}
+                <div class="comment">
+                  <div class="comment-metadata">
+                    <div class="comment-author">
+                      by ${comment.author},
+                    </div>
+                    <div class="comment-date">
+                      ${comment.updatedAt.format('dd MMM yy')}
+                    </div>
+                    #{if comment.author == currentUser.first_name}
+                      <a class=button href="@{Comments.deleteComment(comment.id,user.id)}">delete</a>
+                    #{/if}
+                    #{ if comment.currentUserLiked()}
+                      <a class=button href="@{Comments.unLike(comment.id,user.id)}"> Unlike</a>
+                    #{/if}
+                    #{else}
+                      <a class=button href="@{Comments.addLike(comment.id,user.id)}">Like</a>
+                    #{/else}
+                    <div> ${comment.likes.size()} likes</div>                   
+                  </div>
+                  <div class="comment-content">
+                    ${comment.content.escape().nl2br()}
+                  </div>
+                </div>
+              #{/list}
+              <a class='triggerhide' href='#' onclick='return false;'> -less<br/></a>
+            </div>
+
+            <div class="individual-post-metadata">
+              ${item.likes.size()}
+              #{if user.isFriendsWith(currentUser) || user==currentUser}
+                #{ if item.currentUserLiked()}
+                  <a  href="@{Application.unLike(item.id,user.id)}">Unlike</a>
+                #{/if}
+                #{else}
+                  <a href="@{Application.addLike(item.id,user.id)}">Like</a>
+                #{/else}
+              #{/if}     
+              .
+              <a href="#" onclick="showDiv('comment ${item.id}')">Comment</a>
+              .
+              ${item.updatedAt.format('dd MMM yy')}
+
+              #{if item.author == currentUser}
+                . <a href="@{Posts.deletePost(item.id,user.id)}">delete my post</a>
+              #{/if}
+
+              <div id="comment ${item.id}" style="clear: both;"   class="comment-textarea">
+                #{form @Comments.postComment(item.id, user.id, commentContent)}
+                  <div style="clear:both;">
+                    <textarea name="commentContent" id="commentContent" style="width: 420px; padding: 2px; height: 20px; display: block; font-family: serif; resize: none; overflow-y: hidden;"></textarea>
+                  </div>
+                  <input type="submit" value="Comment"  style="clear:right;margin-top: 3px;" />
+                #{/form}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    #{/list}
+
+
 <a class=button href="@{Events.events()}">< Events</a><br /><br />


### PR DESCRIPTION
Now an Event can have Posts and display Event members. By default the Event author is a member of the Event. 

To do:
Extend Event invites to friends of Event author
Expand categories of Event membership (Definite Attending, Maybe Attending, Not Attending)
Display Events in order of start time on main page

Known Errors:
Event Create "Cancel" button still defective
When submit a post/comment, Event display page needs to be reloaded to display new Event with details
