### PR TITLE
Fixed problem with not allowing the creation of multiple Events

### DIFF
--- a/app/models/Event.java
+++ b/app/models/Event.java
@@ -33,7 +33,7 @@ public class Event extends Model {
   public boolean inviteOnly = false;
   // public Location eventVenue;
 
-  @OneToMany
+  @ManyToMany
   public List<User> members;
 
   public Event(User author, String name, String script,


### PR DESCRIPTION
Small fix: just changed the member list of an Event to support a @ManyToMany relationship between users and events so that it would stop throwing errors when multiple events were being created.
