### PR TITLE
Removed thumbnail conversion to JPEG. Fixes #233.

### DIFF
--- a/app/models/Photo.java
+++ b/app/models/Photo.java
@@ -57,7 +57,6 @@ public class Photo extends Post {
     File thumbnail = Thumbnails.of(image)
                                .size(width, height)
                                .crop(Positions.CENTER)
-                               .outputFormat("jpg")
                                .asFiles(Rename.NO_CHANGE)
                                .get(0);
     return fileToBlob(thumbnail);


### PR DESCRIPTION
Initially, I converted all thumbnails to JPEG. Now the thumbnail filetype always matches the original upload. This prevents breaking things like PNG transparency.
