### PR TITLE
Added photo privacy and improved i18n

### DIFF
--- a/app/controllers/Photos.java
+++ b/app/controllers/Photos.java
@@ -116,7 +116,7 @@ public class Photos extends OBController {
   public static void setProfilePhoto(Long photoId) {
     User user = user();
     Photo photo = Photo.findById(photoId);
-    if (photo == null || !photo.visible(user())) {
+    if (photo == null || !photo.visible(user)) {
       notFound(Messages.get("photo.notFound"));
     }
     if (!photo.owner.equals(user())) {

--- a/app/controllers/Photos.java
+++ b/app/controllers/Photos.java
@@ -57,6 +57,8 @@ public class Photos extends OBController {
     File image = new File(path);
     User user = User.find("username = ?", "default").first();//set owner as default owner
     Photo photo = new Photo(user, image, caption);
+    /* Make all initial photos world-visible. */
+    photo.visibility = Likeable.Visibility.PUBLIC;
     photo.save();
     return photo;
   }

--- a/app/controllers/Photos.java
+++ b/app/controllers/Photos.java
@@ -5,6 +5,7 @@ import java.util.*;
 import javax.imageio.ImageIO;
 import java.io.*;
 import play.*;
+import play.i18n.Messages;
 import play.data.validation.Error;
 import play.libs.*;
 import play.mvc.*;
@@ -34,8 +35,8 @@ public class Photos extends OBController {
 
   public static void getPhoto(Long photoId) {
     Photo photo = Photo.findById(photoId);
-    if (photo == null) {
-      notFound("That photo does not exist.");
+    if (photo == null || !photo.visible(user())) {
+      notFound(Messages.get("photo.notFound"));
     }
     else {
       response.setContentTypeIfNotSet(photo.image.type());
@@ -87,10 +88,12 @@ public class Photos extends OBController {
 
   public static void removePhoto(Long photoId) {
     Photo photo = Photo.findById(photoId);
-    if (photo == null)
-      notFound("That photo does not exist.");
-    if (!photo.owner.equals(user()))
+    if (photo == null) {
+      notFound(Messages.get("photo.notFound"));
+    }
+    if (!photo.owner.equals(user())) {
       forbidden();
+    }
     photo.delete();
     redirect("/users/" + photo.owner.id + "/photos");
   }
@@ -111,11 +114,12 @@ public class Photos extends OBController {
   public static void setProfilePhoto(Long photoId) {
     User user = user();
     Photo photo = Photo.findById(photoId);
-    if (photo == null)
-      notFound("That photo does not exist.");
-
-    if (!photo.owner.equals(user()))
+    if (photo == null || !photo.visible(user())) {
+      notFound(Messages.get("photo.notFound"));
+    }
+    if (!photo.owner.equals(user())) {
       forbidden();
+    }
 
     user.profile.profilePhoto = photo;
     user.profile.save();

--- a/app/controllers/Thumbnails.java
+++ b/app/controllers/Thumbnails.java
@@ -1,38 +1,36 @@
 package controllers;
 
+import play.i18n.Messages;
+import play.db.jpa.Blob;
 import models.Photo;
 
 public class Thumbnails extends OBController {
-  public static void get120x120(Long photoId) {
+
+  private static Photo getPhotoIfVisible(long photoId) {
     Photo photo = Photo.findById(photoId);
-    if (photo == null) {
-      notFound("That photo does not exist.");
+    if (photo == null || !photo.visible(user())) {
+      notFound(Messages.get("photo.notFound"));
     }
-    else {
-      response.setContentTypeIfNotSet(photo.thumbnail120x120.type());
-      renderBinary(photo.thumbnail120x120.get());
-    }
+    return photo;
+  }
+
+  private static void renderBlob(Blob thumbnail) {
+    response.setContentTypeIfNotSet(thumbnail.type());
+    renderBinary(thumbnail.get());
+  }
+
+  public static void get120x120(Long photoId) {
+    Photo photo = getPhotoIfVisible(photoId);
+    renderBlob(photo.thumbnail120x120);
   }
 
   public static void get50x50(Long photoId) {
-    Photo photo = Photo.findById(photoId);
-    if (photo == null) {
-      notFound("That photo does not exist.");
-    }
-    else {
-      response.setContentTypeIfNotSet(photo.thumbnail50x50.type());
-      renderBinary(photo.thumbnail50x50.get());
-    }
+    Photo photo = getPhotoIfVisible(photoId);
+    renderBlob(photo.thumbnail50x50);
   }
 
   public static void get30x30(Long photoId) {
-    Photo photo = Photo.findById(photoId);
-    if (photo == null) {
-      notFound("That photo does not exist.");
-    }
-    else {
-      response.setContentTypeIfNotSet(photo.thumbnail30x30.type());
-      renderBinary(photo.thumbnail30x30.get());
-    }
+    Photo photo = getPhotoIfVisible(photoId);
+    renderBlob(photo.thumbnail30x30);
   }
 }

--- a/app/models/Photo.java
+++ b/app/models/Photo.java
@@ -13,12 +13,14 @@ import net.coobird.thumbnailator.geometry.*;
 import net.coobird.thumbnailator.name.*;
 
 @Entity
-public class Photo extends Post {
+public class Photo extends Commentable {
 
   public static final int MAX_PIXEL_SIZE = 1024;
 
   @Required
   public Blob image;
+
+  public String caption;
 
   @Required
   public Blob thumbnail120x120,
@@ -27,13 +29,14 @@ public class Photo extends Post {
 
   public Photo(User owner, File image) throws IOException,
                                               FileNotFoundException {
-    this(owner, image, "");
+    this(owner, image, null);
   }
 
   public Photo(User owner, File image, String caption)
                                       throws IOException,
                                              FileNotFoundException {
-    super(owner, owner, caption);
+    super(owner);
+    this.caption = caption;
     shrinkImage(image);
     this.image = fileToBlob(image);
     this.createThumbnails();

--- a/conf/messages
+++ b/conf/messages
@@ -91,6 +91,7 @@ photo.setAsProfilePhoto=Set as Profile Photo
 photo.useGravatar="Use Gravatar"
 photo.signUpGravatar=Sign up to use Gravatar
 photo.gravatarNote=Note: After signing up, it may take some time for the photo to propagate.
+photo.notFound=That photo does not exist.
 
 #Threads
 thread.title=Public Threads


### PR DESCRIPTION
Now only people who have access to any photo may view it. Otherwise, they receive a "photo not found" error. 

Also changed the inheritance structure of `Photo`, making it extend `Commentable` instead of `Post`. This fixes issue #231 and will better integrate with the new timeline implementation.

And... photo tests are still green!
